### PR TITLE
Speeding up parsing protobuf messages with the memoryview

### DIFF
--- a/protobuf3/message.py
+++ b/protobuf3/message.py
@@ -34,18 +34,18 @@ class Message(object):
         setattr(cls, field_name, field_instance)
 
     def __init__(self):
+        self.__read_offset = 0
         self.__wire_message = {}
         self.__parent = None
 
-    @staticmethod
-    def _decode_field_signature(input_iterator):
-        number = Message._decode_varint(input_iterator)
+    def _decode_field_signature(self, data):
+        number = self._decode_varint(data)
 
         field_type = number & 0b111
         field_number = number >> 3
 
         if field_type == FIELD_VARIABLE_LENGTH:
-            field_length = Message._decode_varint(input_iterator)
+            field_length = self._decode_varint(data)
         elif field_type in (FIELD_START_GROUP, FIELD_END_GROUP):
             raise NotImplementedError("Groups is deprecated and unsupported in protobuf3")
         elif field_type in (FIELD_VARINT, FIELD_FIXED64, FIELD_FIXED32):
@@ -69,17 +69,18 @@ class Message(object):
 
         return result
 
-    @staticmethod
-    def _decode_varint(input_iterator):
-        result = []
-        while True:
-            next_byte = next(input_iterator)
-            result.append(next_byte & 0b01111111)
-            if not next_byte & (1 << 7):
-                return reduce(lambda a, b: a + b,
-                              map(lambda a, b: a * b,
-                                  result,
-                                  [(1 << 7) ** i for i in range(len(result))]))
+    def _decode_varint(self, data):
+        # Not very pretty, but fast
+        varint = 0
+        for offset, byte in enumerate(data[self.__read_offset:]):
+            varint += (1 << 7) ** offset * (byte & 0b01111111)
+            if not byte & (1 << 7):
+                break
+
+        # Adjust offset to the next byte
+        self.__read_offset += offset + 1
+
+        return varint
 
     @staticmethod
     def _encode_varint(number):
@@ -98,16 +99,15 @@ class Message(object):
 
         return bytes(result)
 
-    def _decode_raw_message(self, input_iterator):
+    def _decode_raw_message(self, data):
         def __read_n_bytes(n):
-            result = bytearray()
-            for _ in range(n):
-                result.append(next(input_iterator))
-            return bytes(result)
+            result = bytes(data[self.__read_offset:self.__read_offset + n])
+            self.__read_offset += n
+            return result
 
         try:
-            while True:
-                field_signature = Message._decode_field_signature(input_iterator)
+            while self.__read_offset < len(data):
+                field_signature = self._decode_field_signature(data)
                 field_type, field_number, field_length = field_signature
                 field_object = self.__fields.get(field_number, BaseField(field_number))
 
@@ -115,7 +115,7 @@ class Message(object):
                     raise ValueError
 
                 if field_type == FIELD_VARINT:
-                    field_value = Message._decode_varint(input_iterator)
+                    field_value = self._decode_varint(data)
                 elif field_type == FIELD_FIXED64:
                     field_value = __read_n_bytes(8)
                 elif field_type == FIELD_VARIABLE_LENGTH:
@@ -177,8 +177,8 @@ class Message(object):
 
     def parse_from_bytes(self, bytes_array):
         self.__wire_message = {}
-        input_iterator = iter(bytes_array)
-        self._decode_raw_message(input_iterator)
+        data = memoryview(bytes_array)
+        self._decode_raw_message(data)
 
         self._check_required_fields()
 

--- a/protobuf3/message.py
+++ b/protobuf3/message.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from functools import reduce
 from protobuf3.fields.base import BaseField
 from protobuf3.wire_types import *
 

--- a/protobuf3/message.py
+++ b/protobuf3/message.py
@@ -72,6 +72,7 @@ class Message(object):
     def _decode_varint(self, data):
         # Not very pretty, but fast
         varint = 0
+        offset = 0
         for offset, byte in enumerate(data[self.__read_offset:]):
             varint += (1 << 7) ** offset * (byte & 0b01111111)
             if not byte & (1 << 7):

--- a/protobuf3/message.py
+++ b/protobuf3/message.py
@@ -72,7 +72,6 @@ class Message(object):
     def _decode_varint(self, data):
         # Not very pretty, but fast
         varint = 0
-        offset = 0
         for offset, byte in enumerate(data[self.__read_offset:]):
             varint += (1 << 7) ** offset * (byte & 0b01111111)
             if not byte & (1 << 7):

--- a/tests/fields/test_base.py
+++ b/tests/fields/test_base.py
@@ -15,10 +15,10 @@ class TestBaseField(TestCase):
             a = StringField(field_number=1, repeated=True)
             b = StringField(field_number=2, repeated=True)
 
-        raw_message = [
+        raw_message = bytes([
             0x0A, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67,
             0x0A, 0x08, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x31
-        ]
+        ])
 
         self.empty_msg = EmptyMessage()
         self.repeated_msg = TestMessage()

--- a/tests/fields/test_bytes.py
+++ b/tests/fields/test_bytes.py
@@ -13,7 +13,7 @@ class TestBytesField(TestCase):
     def test_get(self):
         msg = self.msg_cls()
 
-        msg.parse_from_bytes([0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67])
+        msg.parse_from_bytes(bytes([0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67]))
         self.assertEqual(msg.b, b'testing')
 
     def test_default_get(self):

--- a/tests/fields/test_int64.py
+++ b/tests/fields/test_int64.py
@@ -18,10 +18,10 @@ class TestInt64Field(TestCase):
 
     def test_get_bounds(self):
         msg = self.msg_cls()
-
         msg.parse_from_bytes(b'\x08\xff\xff\xff\xff\xff\xff\xff\xff\x7f')
         self.assertEqual(msg.a, 2 ** 63 - 1)
 
+        msg = self.msg_cls()
         msg.parse_from_bytes(b'\x08\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
         self.assertEqual(msg.a, -(2 ** 63))
 

--- a/tests/fields/test_string.py
+++ b/tests/fields/test_string.py
@@ -13,7 +13,7 @@ class TestStringField(TestCase):
     def test_get(self):
         msg = self.msg_cls()
 
-        msg.parse_from_bytes([0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67])
+        msg.parse_from_bytes(bytes([0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67]))
         self.assertEqual(msg.b, 'testing')
 
     def test_default_get(self):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -7,18 +7,20 @@ from unittest import TestCase
 class TestMessage(TestCase):
     def test_decode_field_signature(self):
         tmp = Message()
+        data = bytes([0b0001000])
+        self.assertEqual(tmp._decode_field_signature(data), (0, 1, None))
 
-        data = [0b0001000]
-        self.assertEqual(tmp._decode_field_signature(iter(data)), (0, 1, None))
+        tmp = Message()
+        data = bytes([0x12, 0x07])
+        self.assertEqual(tmp._decode_field_signature(data), (2, 2, 7))
 
-        data = [0x12, 0x07]
-        self.assertEqual(tmp._decode_field_signature(iter(data)), (2, 2, 7))
+        tmp = Message()
+        data = bytes([0b00001011])
+        self.assertRaises(NotImplementedError, tmp._decode_field_signature, data)
 
-        data = [0b00001011]
-        self.assertRaises(NotImplementedError, tmp._decode_field_signature, iter(data))
-
-        data = [0b00001111]
-        self.assertRaises(ValueError, tmp._decode_field_signature, iter(data))
+        tmp = Message()
+        data = bytes([0b00001111])
+        self.assertRaises(ValueError, tmp._decode_field_signature, data)
 
     def test_encode_field_signature(self):
         tmp = Message()
@@ -30,18 +32,20 @@ class TestMessage(TestCase):
 
     def test_decode_varint(self):
         tmp = Message()
+        data = bytes([0b00000000])
+        self.assertEqual(tmp._decode_varint(data), 0)
 
-        data = [0b00000000]
-        self.assertEqual(tmp._decode_varint(iter(data)), 0)
+        tmp = Message()
+        data = bytes([0b00000001])
+        self.assertEqual(tmp._decode_varint(data), 1)
 
-        data = [0b00000001]
-        self.assertEqual(tmp._decode_varint(iter(data)), 1)
+        tmp = Message()
+        data = bytes([0b10010110, 0b00000001])
+        self.assertEqual(tmp._decode_varint(data), 150)
 
-        data = [0b10010110, 0b00000001]
-        self.assertEqual(tmp._decode_varint(iter(data)), 150)
-
-        data = [0b10101100, 0b00000010]
-        self.assertEqual(tmp._decode_varint(iter(data)), 300)
+        tmp = Message()
+        data = bytes([0b10101100, 0b00000010])
+        self.assertEqual(tmp._decode_varint(data), 300)
 
     def test_encode_varint(self):
         tmp = Message()
@@ -54,34 +58,34 @@ class TestMessage(TestCase):
     def test_decode_raw_message(self):
         # FIELD_VARINT
         tmp = Message()
-        data = [0x08, 0x96, 0x01]
+        data = bytes([0x08, 0x96, 0x01])
         expected_message = {1: [WireField(type=FIELD_VARINT, value=150)]}
-        tmp._decode_raw_message(iter(data))
+        tmp._decode_raw_message(data)
         self.assertDictEqual(tmp._Message__wire_message, expected_message)
 
         # FIELD_FIXED64
         tmp = Message()
-        data = [0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        data = bytes([0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
         expected_message = {
             1: [WireField(type=FIELD_FIXED64, value=b'\x01\x02\x03\x04\x05\x06\x07\x08')]
         }
-        tmp._decode_raw_message(iter(data))
+        tmp._decode_raw_message(data)
         self.assertDictEqual(tmp._Message__wire_message, expected_message)
 
         # FIELD_VARIABLE_LENGTH
         tmp = Message()
-        data = [0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67]
+        data = bytes([0x12, 0x07, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67])
         expected_message = {
             2: [WireField(type=FIELD_VARIABLE_LENGTH, value=b'testing')]
         }
-        tmp._decode_raw_message(iter(data))
+        tmp._decode_raw_message(data)
         self.assertDictEqual(tmp._Message__wire_message, expected_message)
 
         # FIELD_FIXED32
         tmp = Message()
-        data = [0x0D, 0x01, 0x02, 0x03, 0x04]
+        data = bytes([0x0D, 0x01, 0x02, 0x03, 0x04])
         expected_message = {1: [WireField(type=FIELD_FIXED32, value=b'\x01\x02\x03\x04')]}
-        tmp._decode_raw_message(iter(data))
+        tmp._decode_raw_message(data)
         self.assertDictEqual(tmp._Message__wire_message, expected_message)
 
     def test_decode_incorrect_field_signature(self):
@@ -89,14 +93,14 @@ class TestMessage(TestCase):
             b = StringField(field_number=1)
 
         msg = StringTestMessage()
-        data = [0x08, 0x96, 0x01]
-        self.assertRaises(ValueError, msg._decode_raw_message, iter(data))
+        data = bytes([0x08, 0x96, 0x01])
+        self.assertRaises(ValueError, msg._decode_raw_message, data)
 
     def test_decode_repeated_field_with_different_types(self):
-        raw_message = [
+        raw_message = bytes([
             0x08, 0x96, 0x01,
             0x0D, 0x01, 0x02, 0x03, 0x04
-        ]
+        ])
 
         msg = Message()
         self.assertRaises(ValueError, msg.parse_from_bytes, raw_message)
@@ -111,7 +115,7 @@ class TestMessage(TestCase):
     def test_get_wire_values(self):
         tmp = Message()
 
-        data = [0x08, 0x96, 0x01]
+        data = bytes([0x08, 0x96, 0x01])
         tmp.parse_from_bytes(data)
         self.assertEqual(tmp._get_wire_values(1), [WireField(type=FIELD_VARINT, value=150)])
 
@@ -125,13 +129,13 @@ class TestMessage(TestCase):
     def test_parse_from_bytes(self):
         tmp = Message()
 
-        data = [0x08, 0x96, 0x01]
+        data = bytes([0x08, 0x96, 0x01])
         expected_message = {1: [WireField(type=FIELD_VARINT, value=150)]}
         tmp.parse_from_bytes(data)
         self.assertDictEqual(tmp._Message__wire_message, expected_message)
 
     def test_create_from_bytes(self):
-        data = [0x08, 0x96, 0x01]
+        data = bytes([0x08, 0x96, 0x01])
         expected_message = {1: [WireField(type=FIELD_VARINT, value=150)]}
 
         tmp = Message.create_from_bytes(data)


### PR DESCRIPTION
Parsing code has been rewritten to use memoryviews instead of iterators. There's a decent speedup of 50x in parse-only tests, and about 30-50% in parse-and-access-all-attributes tests. No changes made to the message building code.

protobuf3 with iterators:
![0_old_protobuf](https://cloud.githubusercontent.com/assets/10929676/14119099/a18302f8-f5fd-11e5-8d75-8a5e65dcf676.jpg)

protobuf3 with memoryviews:
![1_new_protobuf](https://cloud.githubusercontent.com/assets/10929676/14119195/17a74a3e-f5fe-11e5-964d-93e981d141bf.jpg)

The functionality remains untouched, except for the create_from_bytes() method no longer accepting anything but bytes (and bytearrays I think). But that's only logical.