### PR TITLE
Fix to encoding of length-delimited fields with zero length

### DIFF
--- a/protobuf3/message.py
+++ b/protobuf3/message.py
@@ -62,7 +62,7 @@ class Message(object):
         result = Message._encode_varint((field_number << 3) | field_type)
 
         if field_type == FIELD_VARIABLE_LENGTH:
-            assert field_length
+            assert field_length is not None
 
             result += Message._encode_varint(field_length)
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -27,6 +27,7 @@ class TestMessage(TestCase):
 
         self.assertEqual(tmp._encode_field_signature(0, 1), b'\x08')
         self.assertEqual(tmp._encode_field_signature(2, 2, 7), b'\x12\x07')
+        self.assertEqual(tmp._encode_field_signature(2, 2, 0), b'\x12\x00')
         self.assertRaises(ValueError, tmp._encode_field_signature, 10, 1)
         self.assertRaises(AssertionError, tmp._encode_field_signature, 2, 2)
 


### PR DESCRIPTION
Encoding Length-delimited fields with zero length (i.e. an empty string) would fail.

This PR contains a test which demonstrates the problem, and a fix.

cheers
